### PR TITLE
rpi5-image: Add kernel modules

### DIFF
--- a/recipes-core/image/rpi5-image-xt-domd.bb
+++ b/recipes-core/image/rpi5-image-xt-domd.bb
@@ -1,0 +1,5 @@
+require rpi5-image-minimal-domd.bb
+
+PACKAGE_INSTALL:append = " \
+    kernel-modules \
+"


### PR DESCRIPTION
Add kernel modules to linux rootfs.
Add dependencies for do_image routine