### PR TITLE
xen: Add patches to xen for dom0less

### DIFF
--- a/recipes-extended/xen/files/0001-xen-arm-dom0less-build-Alloc-magic-pages-for-Dom0les.patch
+++ b/recipes-extended/xen/files/0001-xen-arm-dom0less-build-Alloc-magic-pages-for-Dom0les.patch
@@ -1,0 +1,107 @@
+From 83988ff44e53f35f88aa748d6f66051db57f36f5 Mon Sep 17 00:00:00 2001
+From: Henry Wang <xin.wang2@amd.com>
+Date: Fri, 26 Apr 2024 11:14:53 +0800
+Subject: [PATCH 1/3] xen/arm/dom0less-build: Alloc magic pages for Dom0less
+ DomUs from hypervisor
+
+There are use cases (for example using the PV driver) in Dom0less
+setup that require Dom0less DomUs start immediately with Dom0, but
+initialize XenStore later after Dom0's successful boot and call to
+the init-dom0less application.
+
+An error message can seen from the init-dom0less application on
+1:1 direct-mapped domains:
+```
+Allocating magic pages
+memory.c:238:d0v0 mfn 0x39000 doesn't belong to d1
+Error on alloc magic pages
+```
+This is because currently the magic pages for Dom0less DomUs are
+populated by the init-dom0less app through populate_physmap(), and
+populate_physmap() automatically assumes gfn == mfn for 1:1 direct
+mapped domains. This cannot be true for the magic pages that are
+allocated later from the init-dom0less application executed in Dom0.
+For domain using statically allocated memory but not 1:1 direct-mapped,
+similar error "failed to retrieve a reserved page" can be seen as the
+reserved memory list is empty at that time.
+
+To solve above issue, this commit allocates the magic pages for
+Dom0less DomUs at the domain construction time. The base address/PFN
+of the magic page region will be noted and communicated to the
+init-dom0less application in Dom0.
+
+Reported-by: Alec Kwapis <alec.kwapis@medtronic.com>
+Suggested-by: Daniel P. Smith <dpsmith@apertussolutions.com>
+Signed-off-by: Henry Wang <xin.wang2@amd.com>
+Message-ID: <20240426031455.579637-2-xin.wang2@amd.com>
+---
+ tools/libs/guest/xg_dom_arm.c |  1 -
+ xen/arch/arm/dom0less-build.c | 22 ++++++++++++++++++++++
+ xen/include/public/arch-arm.h |  1 +
+ 3 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/guest/xg_dom_arm.c b/tools/libs/guest/xg_dom_arm.c
+index 2fd8ee7ad4..8cc7f27dbb 100644
+--- a/tools/libs/guest/xg_dom_arm.c
++++ b/tools/libs/guest/xg_dom_arm.c
+@@ -25,7 +25,6 @@
+ 
+ #include "xg_private.h"
+ 
+-#define NR_MAGIC_PAGES 4
+ #define CONSOLE_PFN_OFFSET 0
+ #define XENSTORE_PFN_OFFSET 1
+ #define MEMACCESS_PFN_OFFSET 2
+diff --git a/xen/arch/arm/dom0less-build.c b/xen/arch/arm/dom0less-build.c
+index fb63ec6fd1..40dc85c759 100644
+--- a/xen/arch/arm/dom0less-build.c
++++ b/xen/arch/arm/dom0less-build.c
+@@ -834,11 +834,33 @@ static int __init construct_domU(struct domain *d,
+ 
+     if ( kinfo.dom0less_feature & DOM0LESS_XENSTORE )
+     {
++        struct page_info *magic_pg;
++        mfn_t mfn;
++        gfn_t gfn;
++
+         ASSERT(hardware_domain);
+         rc = alloc_xenstore_evtchn(d);
+         if ( rc < 0 )
+             return rc;
+         d->arch.hvm.params[HVM_PARAM_STORE_PFN] = ~0ULL;
++
++        d->max_pages += NR_MAGIC_PAGES;
++        magic_pg = alloc_domheap_pages(d, get_order_from_pages(NR_MAGIC_PAGES), 0);
++        if ( magic_pg == NULL )
++            return -ENOMEM;
++
++        mfn = page_to_mfn(magic_pg);
++        if ( !is_domain_direct_mapped(d) )
++            gfn = gaddr_to_gfn(GUEST_MAGIC_BASE);
++        else
++            gfn = gaddr_to_gfn(mfn_to_maddr(mfn));
++
++        rc = guest_physmap_add_pages(d, gfn, mfn, NR_MAGIC_PAGES);
++        if ( rc )
++        {
++            free_domheap_pages(magic_pg, get_order_from_pages(NR_MAGIC_PAGES));
++            return rc;
++        }
+     }
+ 
+     return rc;
+diff --git a/xen/include/public/arch-arm.h b/xen/include/public/arch-arm.h
+index ca610f1b17..71bc8f11d1 100644
+--- a/xen/include/public/arch-arm.h
++++ b/xen/include/public/arch-arm.h
+@@ -497,6 +497,7 @@ typedef uint64_t xen_callback_t;
+ 
+ #define GUEST_MAGIC_BASE  xen_mk_ullong(0x39000000)
+ #define GUEST_MAGIC_SIZE  xen_mk_ullong(0x01000000)
++#define NR_MAGIC_PAGES 4
+ 
+ /* 64 MB is reserved for virtio-pci Prefetch memory */
+ #define GUEST_VIRTIO_PCI_ADDR_TYPE_PREFETCH_MEM    xen_mk_ullong(0x42000000)
+-- 
+2.34.1
+

--- a/recipes-extended/xen/files/0002-xen-arm-tools-Add-a-new-HVM_PARAM_MAGIC_BASE_PFN-key.patch
+++ b/recipes-extended/xen/files/0002-xen-arm-tools-Add-a-new-HVM_PARAM_MAGIC_BASE_PFN-key.patch
@@ -1,0 +1,81 @@
+From 37f831757c3ddba875edf83499691bee3ef9c113 Mon Sep 17 00:00:00 2001
+From: Henry Wang <xin.wang2@amd.com>
+Date: Fri, 26 Apr 2024 11:14:54 +0800
+Subject: [PATCH 2/3] xen/arm, tools: Add a new HVM_PARAM_MAGIC_BASE_PFN key in
+ HVMOP
+
+For use cases such as Dom0less PV drivers, a mechanism to communicate
+Dom0less DomU's static data with the runtime control plane (Dom0) is
+needed. Since on Arm HVMOP is already the existing approach to address
+such use cases (for example the allocation of HVM_PARAM_CALLBACK_IRQ),
+add a new HVMOP key HVM_PARAM_MAGIC_BASE_PFN for storing the magic
+page region base PFN. The value will be set at Dom0less DomU
+construction time after Dom0less DomU's magic page region has been
+allocated.
+
+To keep consistent, also set the value for HVM_PARAM_MAGIC_BASE_PFN
+for libxl guests in alloc_magic_pages().
+
+Reported-by: Alec Kwapis <alec.kwapis@medtronic.com>
+Signed-off-by: Henry Wang <xin.wang2@amd.com>
+Message-ID: <20240426031455.579637-3-xin.wang2@amd.com>
+---
+ tools/libs/guest/xg_dom_arm.c   | 2 ++
+ xen/arch/arm/dom0less-build.c   | 2 ++
+ xen/arch/arm/hvm.c              | 1 +
+ xen/include/public/hvm/params.h | 1 +
+ 4 files changed, 6 insertions(+)
+
+diff --git a/tools/libs/guest/xg_dom_arm.c b/tools/libs/guest/xg_dom_arm.c
+index 8cc7f27dbb..3c08782d1d 100644
+--- a/tools/libs/guest/xg_dom_arm.c
++++ b/tools/libs/guest/xg_dom_arm.c
+@@ -74,6 +74,8 @@ static int alloc_magic_pages(struct xc_dom_image *dom)
+     xc_clear_domain_page(dom->xch, dom->guest_domid, base + MEMACCESS_PFN_OFFSET);
+     xc_clear_domain_page(dom->xch, dom->guest_domid, dom->vuart_gfn);
+ 
++    xc_hvm_param_set(dom->xch, dom->guest_domid, HVM_PARAM_MAGIC_BASE_PFN,
++            base);
+     xc_hvm_param_set(dom->xch, dom->guest_domid, HVM_PARAM_CONSOLE_PFN,
+             dom->console_pfn);
+     xc_hvm_param_set(dom->xch, dom->guest_domid, HVM_PARAM_STORE_PFN,
+diff --git a/xen/arch/arm/dom0less-build.c b/xen/arch/arm/dom0less-build.c
+index 40dc85c759..72187c167d 100644
+--- a/xen/arch/arm/dom0less-build.c
++++ b/xen/arch/arm/dom0less-build.c
+@@ -861,6 +861,8 @@ static int __init construct_domU(struct domain *d,
+             free_domheap_pages(magic_pg, get_order_from_pages(NR_MAGIC_PAGES));
+             return rc;
+         }
++
++        d->arch.hvm.params[HVM_PARAM_MAGIC_BASE_PFN] = gfn_x(gfn);
+     }
+ 
+     return rc;
+diff --git a/xen/arch/arm/hvm.c b/xen/arch/arm/hvm.c
+index 0989309fea..fa6141e30c 100644
+--- a/xen/arch/arm/hvm.c
++++ b/xen/arch/arm/hvm.c
+@@ -55,6 +55,7 @@ static int hvm_allow_get_param(const struct domain *d, unsigned int param)
+     case HVM_PARAM_STORE_EVTCHN:
+     case HVM_PARAM_CONSOLE_PFN:
+     case HVM_PARAM_CONSOLE_EVTCHN:
++    case HVM_PARAM_MAGIC_BASE_PFN:
+         return 0;
+ 
+         /*
+diff --git a/xen/include/public/hvm/params.h b/xen/include/public/hvm/params.h
+index a22b4ed45d..c1720b33b9 100644
+--- a/xen/include/public/hvm/params.h
++++ b/xen/include/public/hvm/params.h
+@@ -76,6 +76,7 @@
+  */
+ #define HVM_PARAM_STORE_PFN    1
+ #define HVM_PARAM_STORE_EVTCHN 2
++#define HVM_PARAM_MAGIC_BASE_PFN    3
+ 
+ #define HVM_PARAM_IOREQ_PFN    5
+ 
+-- 
+2.34.1
+

--- a/recipes-extended/xen/files/0003-tools-init-dom0less-Avoid-hardcoding-GUEST_MAGIC_BAS.patch
+++ b/recipes-extended/xen/files/0003-tools-init-dom0less-Avoid-hardcoding-GUEST_MAGIC_BAS.patch
@@ -1,0 +1,112 @@
+From 9c6aa42c547835372b9a13ef197f646a86229be3 Mon Sep 17 00:00:00 2001
+From: Henry Wang <xin.wang2@amd.com>
+Date: Fri, 26 Apr 2024 11:14:55 +0800
+Subject: [PATCH 3/3] tools/init-dom0less: Avoid hardcoding GUEST_MAGIC_BASE
+
+Currently the GUEST_MAGIC_BASE in the init-dom0less application is
+hardcoded, which will lead to failures for 1:1 direct-mapped Dom0less
+DomUs.
+
+Since the guest magic region is now allocated from the hypervisor,
+instead of hardcoding the guest magic pages region, use
+xc_hvm_param_get() to get the guest magic region PFN, and based on
+that the XenStore PFN can be calculated. Also, we don't need to set
+the max mem anymore, so drop the call to xc_domain_setmaxmem(). Rename
+the alloc_xs_page() to get_xs_page() to reflect the changes.
+
+Take the opportunity to do some coding style improvements when possible.
+
+Reported-by: Alec Kwapis <alec.kwapis@medtronic.com>
+Signed-off-by: Henry Wang <xin.wang2@amd.com>
+Message-ID: <20240426031455.579637-4-xin.wang2@amd.com>
+---
+ tools/helpers/init-dom0less.c | 38 +++++++++++++++--------------------
+ 1 file changed, 16 insertions(+), 22 deletions(-)
+
+diff --git a/tools/helpers/init-dom0less.c b/tools/helpers/init-dom0less.c
+index fee93459c4..7f6953a818 100644
+--- a/tools/helpers/init-dom0less.c
++++ b/tools/helpers/init-dom0less.c
+@@ -19,24 +19,20 @@
+ #define XENSTORE_PFN_OFFSET 1
+ #define STR_MAX_LENGTH 128
+ 
+-static int alloc_xs_page(struct xc_interface_core *xch,
+-                         libxl_dominfo *info,
+-                         uint64_t *xenstore_pfn)
++static int get_xs_page(struct xc_interface_core *xch, libxl_dominfo *info,
++                       uint64_t *xenstore_pfn)
+ {
+     int rc;
+-    const xen_pfn_t base = GUEST_MAGIC_BASE >> XC_PAGE_SHIFT;
+-    xen_pfn_t p2m = (GUEST_MAGIC_BASE >> XC_PAGE_SHIFT) + XENSTORE_PFN_OFFSET;
++    xen_pfn_t magic_base_pfn;
+ 
+-    rc = xc_domain_setmaxmem(xch, info->domid,
+-                             info->max_memkb + (XC_PAGE_SIZE/1024));
+-    if (rc < 0)
+-        return rc;
+-
+-    rc = xc_domain_populate_physmap_exact(xch, info->domid, 1, 0, 0, &p2m);
+-    if (rc < 0)
+-        return rc;
++    rc = xc_hvm_param_get(xch, info->domid, HVM_PARAM_MAGIC_BASE_PFN,
++                          &magic_base_pfn);
++    if (rc < 0) {
++        printf("Failed to get HVM_PARAM_MAGIC_BASE_PFN\n");
++        return 1;
++    }
+ 
+-    *xenstore_pfn = base + XENSTORE_PFN_OFFSET;
++    *xenstore_pfn = magic_base_pfn + XENSTORE_PFN_OFFSET;
+     rc = xc_clear_domain_page(xch, info->domid, *xenstore_pfn);
+     if (rc < 0)
+         return rc;
+@@ -100,6 +96,7 @@ static bool do_xs_write_vm(struct xs_handle *xsh, xs_transaction_t t,
+  */
+ static int create_xenstore(struct xs_handle *xsh,
+                            libxl_dominfo *info, libxl_uuid uuid,
++                           xen_pfn_t xenstore_pfn,
+                            evtchn_port_t xenstore_port)
+ {
+     domid_t domid;
+@@ -145,8 +142,7 @@ static int create_xenstore(struct xs_handle *xsh,
+     rc = snprintf(target_memkb_str, STR_MAX_LENGTH, "%"PRIu64, info->current_memkb);
+     if (rc < 0 || rc >= STR_MAX_LENGTH)
+         return rc;
+-    rc = snprintf(ring_ref_str, STR_MAX_LENGTH, "%lld",
+-                  (GUEST_MAGIC_BASE >> XC_PAGE_SHIFT) + XENSTORE_PFN_OFFSET);
++    rc = snprintf(ring_ref_str, STR_MAX_LENGTH, "%"PRIu_xen_pfn, xenstore_pfn);
+     if (rc < 0 || rc >= STR_MAX_LENGTH)
+         return rc;
+     rc = snprintf(xenstore_port_str, STR_MAX_LENGTH, "%u", xenstore_port);
+@@ -245,8 +241,8 @@ static int init_domain(struct xs_handle *xsh,
+     if (!xenstore_evtchn)
+         return 0;
+ 
+-    /* Alloc xenstore page */
+-    if (alloc_xs_page(xch, info, &xenstore_pfn) != 0) {
++    /* Get xenstore page */
++    if (get_xs_page(xch, info, &xenstore_pfn) != 0) {
+         printf("Error on alloc magic pages\n");
+         return 1;
+     }
+@@ -278,13 +274,11 @@ static int init_domain(struct xs_handle *xsh,
+     if (rc < 0)
+         return rc;
+ 
+-    rc = create_xenstore(xsh, info, uuid, xenstore_evtchn);
++    rc = create_xenstore(xsh, info, uuid, xenstore_pfn, xenstore_evtchn);
+     if (rc)
+         err(1, "writing to xenstore");
+ 
+-    rc = xs_introduce_domain(xsh, info->domid,
+-            (GUEST_MAGIC_BASE >> XC_PAGE_SHIFT) + XENSTORE_PFN_OFFSET,
+-            xenstore_evtchn);
++    rc = xs_introduce_domain(xsh, info->domid, xenstore_pfn, xenstore_evtchn);
+     if (!rc)
+         err(1, "xs_introduce_domain");
+     return 0;
+-- 
+2.34.1
+

--- a/recipes-extended/xen/xen-tools_git.bbappend
+++ b/recipes-extended/xen/xen-tools_git.bbappend
@@ -1,6 +1,7 @@
 # Avoid redundant runtime dependency on python3-core
 RDEPENDS:${PN}:remove:class-target = " ${PYTHON_PN}-core" 
 
+require xen.inc
 require xen-source.inc
 
 PACKAGECONFIG:append = " xsm"

--- a/recipes-extended/xen/xen.inc
+++ b/recipes-extended/xen/xen.inc
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " \
+    file://0001-xen-arm-dom0less-build-Alloc-magic-pages-for-Dom0les.patch \
+    file://0002-xen-arm-tools-Add-a-new-HVM_PARAM_MAGIC_BASE_PFN-key.patch \
+    file://0003-tools-init-dom0less-Avoid-hardcoding-GUEST_MAGIC_BAS.patch \
+"

--- a/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-extended/xen/xen_git.bbappend
@@ -1,5 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+require xen.inc
 require xen-source.inc
 
 SRC_URI:append = " \


### PR DESCRIPTION
Add patch series to xen. This series is trying to fix the reported guest magic region allocation issue for 1:1 direct-mapped Dom0less domUs.