### PR TITLE
rpi5-image-xt: Make sure boot files deployed before do_image

### DIFF
--- a/recipes-core/image/rpi5-image-minimal-domd.bb
+++ b/recipes-core/image/rpi5-image-minimal-domd.bb
@@ -7,6 +7,13 @@ EXTRA_IMAGE_FEATURES += "package-management"
 
 RDEPENDS += "rpi-bootfiles"
 
+do_image[depends] += " \
+    rpi-bootfiles:do_deploy \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot-tools-native:do_populate_sysroot', '',d)} \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot:do_deploy', '',d)} \
+    ${@bb.utils.contains('RPI_USE_U_BOOT', '1', 'u-boot-default-script:do_deploy', '',d)} \
+"
+
 # Basic packages
 PACKAGE_INSTALL:append = " \
     coreutils \


### PR DESCRIPTION
Make sure boot files deployed before do_image. This should minimize or eliminate issue when boot firmware files don't deploy.