### PR TITLE
Add possibility to configure bootargs

### DIFF
--- a/recipes-bsp/xt-rpi-u-boot-scr/files/boot.cmd.xen.in
+++ b/recipes-bsp/xt-rpi-u-boot-scr/files/boot.cmd.xen.in
@@ -4,6 +4,8 @@ fdt addr @@XEN_DTB_ADDR@@
 fdt resize 2048
 fdt chosen
 
+fdt set /chosen xen,dom0-bootargs "@@DOM0_BOOTARGS@@";
+fdt set /chosen xen,xen-bootargs "@@XEN_BOOTARGS@@";
 fatload @@BOOT_MEDIA@@ 0 @@XENPOLICY_IMG_ADDR@@ @@XENPOLICY_IMAGE@@
 fdt set /chosen/xenpolicy reg <0x0 @@XENPOLICY_IMG_ADDR@@ 0x0 0x${filesize} >
 
@@ -12,7 +14,7 @@ fdt set /chosen/dom0 reg <0x0 @@DOM0_IMG_ADDR@@ 0x0 0x${filesize} >
 
 fdt mknod /chosen/domD module@@@DOMD_IMG_ADDR@@
 fdt set /chosen/domD/module@@@DOMD_IMG_ADDR@@ compatible  "multiboot,kernel" "multiboot,module"
-fdt set /chosen/domD/module@@@DOMD_IMG_ADDR@@ bootargs "console=ttyAMA0 earlycon=xen earlyprintk=xen clk_ignore_unused root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
+fdt set /chosen/domD/module@@@DOMD_IMG_ADDR@@ bootargs "@@DOMD_BOOTARGS@@"
 fatload @@BOOT_MEDIA@@ 0 @@DOMD_IMG_ADDR@@ @@DOMD_IMAGE@@
 fdt set /chosen/domD/module@@@DOMD_IMG_ADDR@@ reg <0x0 @@DOMD_IMG_ADDR@@ 0x0 0x${filesize} >
 

--- a/recipes-bsp/xt-rpi-u-boot-scr/xt-rpi-u-boot-scr.bb
+++ b/recipes-bsp/xt-rpi-u-boot-scr/xt-rpi-u-boot-scr.bb
@@ -30,6 +30,9 @@ XENPOLICY_IMAGE ?= "xenpolicy"
 XENPOLICY_IMG_ADDR ?= "0x2300000"
 UBOOT_BOOT_SCRIPT ?= "boot.scr"
 UBOOT_BOOT_SCRIPT_SOURCE ?= "boot.cmd"
+XEN_BOOTARGS ?= "console=dtuart dtuart=\/soc\/serial@7d001000 dom0_mem=128M dom0_max_vcpus=1 xsm=flask flask=permissive"
+DOM0_BOOTARGS ?= "console=hvc0 earlycon=xen earlyprintk=xen clk_ignore_unused root=\/dev\/ram0"
+DOMD_BOOTARGS ?= "console=ttyAMA0 earlycon=xen earlyprintk=xen clk_ignore_unused root=\/dev\/mmcblk0p2 rootfstype=ext4 rootwait"
 
 do_compile() {
     sed -e 's/@@BOOT_MEDIA@@/${BOOT_MEDIA}/g' \
@@ -45,6 +48,9 @@ do_compile() {
         -e 's/@@DOMD_DTB_ADDR@@/${DOMD_DTB_ADDR}/g' \
         -e 's/@@DOMD_IMAGE@@/${DOMD_IMAGE}/g' \
         -e 's/@@DOMD_IMG_ADDR@@/${DOMD_IMG_ADDR}/g' \
+        -e 's/@@XEN_BOOTARGS@@/${XEN_BOOTARGS}/g' \
+        -e 's/@@DOM0_BOOTARGS@@/${DOM0_BOOTARGS}/g' \
+        -e 's/@@DOMD_BOOTARGS@@/${DOMD_BOOTARGS}/g' \
         "${WORKDIR}/${TEMPLATE_FILE}" > "${WORKDIR}/${UBOOT_BOOT_SCRIPT_SOURCE}"
 
     mkimage -A ${UBOOT_ARCH} -T script -C none -n "Boot script" -d "${WORKDIR}/${UBOOT_BOOT_SCRIPT_SOURCE}" ${UBOOT_BOOT_SCRIPT}


### PR DESCRIPTION
Bootargs for dom0 and domd can be configured via DOM0_BOOTARGS and DOMD_BOOTARGS variables respectively. Values for those variables used in regular expression so any control character for regular expression should be escaped with backslash.