### PR TITLE
u-boot: set u-boot sources to xentroops repository

### DIFF
--- a/recipes-bsp/u-boot/u-boot-src.inc
+++ b/recipes-bsp/u-boot/u-boot-src.inc
@@ -1,0 +1,2 @@
+SRCREV = "5f19ce099d7e4eca6f46e767dfc48e8d1e78a746"
+SRC_URI = "git://github.com/xen-troops/u-boot.git;protocol=https;branch=rpi5-2024.04-xt"

--- a/recipes-bsp/u-boot/u-boot-tools_2024.04.bb
+++ b/recipes-bsp/u-boot/u-boot-tools_2024.04.bb
@@ -1,4 +1,3 @@
 require recipes-bsp/u-boot/u-boot.inc
 require recipes-bsp/u-boot/u-boot-common.inc
-
-SRCREV = "13c1100335e40acb1066e074eb061387fd103c36"
+require u-boot-src.inc

--- a/recipes-bsp/u-boot/u-boot_2024.04.bb
+++ b/recipes-bsp/u-boot/u-boot_2024.04.bb
@@ -1,7 +1,6 @@
 require recipes-bsp/u-boot/u-boot.inc
 require recipes-bsp/u-boot/u-boot-common.inc
-
-SRCREV = "13c1100335e40acb1066e074eb061387fd103c36"
+require u-boot-src.inc
 
 DEPENDS += "bc-native dtc-native python3-pyelftools-native"
 


### PR DESCRIPTION
Set u-boot sources to the repository with support an enhanced support of the RPI5 devices.