### PR TITLE
Make meta-xt-rpi5 more generic so it can be used by other products

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_xt-rpi5 := "^${LAYERDIR}/"
 BBFILE_PRIORITY_xt-rpi5 = "10"
 
 LAYERSERIES_COMPAT_xt-rpi5 = "scarthgap"
-LAYERDEPENDS_xt-rpi5 = "core xt-security"
+LAYERDEPENDS_xt-rpi5 = "core xt-security raspberrypi"

--- a/recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc
+++ b/recipes-bsp/trusted-firmware-a/trusted-firmware-a.inc
@@ -9,6 +9,8 @@ SRC_URI_TRUSTED_FIRMWARE_A ?= "git://review.trustedfirmware.org/TF-A/trusted-fir
 SRCBRANCH = "master"
 SRC_URI = "${SRC_URI_TRUSTED_FIRMWARE_A};name=tfa;branch=${SRCBRANCH}"
 
+CCACHE_DISABLE = "1"
+
 UPSTREAM_CHECK_GITTAGREGEX = "^(lts-)?v(?P<pver>\d+(\.\d+)+)$"
 
 SRCREV_FORMAT = "tfa"

--- a/recipes-core/image/rpi5-image-xt-domd.bb
+++ b/recipes-core/image/rpi5-image-xt-domd.bb
@@ -1,5 +1,1 @@
 require rpi5-image-minimal-domd.bb
-
-PACKAGE_INSTALL:append = " \
-    kernel-modules \
-"

--- a/recipes-extended/xen/xen-tools_git.bbappend
+++ b/recipes-extended/xen/xen-tools_git.bbappend
@@ -1,5 +1,5 @@
 # Avoid redundant runtime dependency on python3-core
-RDEPENDS:${PN}:remove:class-target = " ${PYTHON_PN}-core" 
+RDEPENDS:${PN}:remove:class-target = " ${PYTHON_PN}-core"
 
 require xen.inc
 require xen-source.inc
@@ -14,8 +14,8 @@ FILES:${PN}-vchan:append = "\
 
 do_install:append() {
     install -d ${D}${bindir}
-    install -m 0755 ${S}/tools/vchan/vchan-node1 ${D}${bindir} 
-    install -m 0755 ${S}/tools/vchan/vchan-node2 ${D}${bindir} 
+    install -m 0755 ${S}/tools/vchan/vchan-node1 ${D}${bindir}
+    install -m 0755 ${S}/tools/vchan/vchan-node2 ${D}${bindir}
 }
 
 # Remove the recommendation for Qemu for non-hvm x86 added in meta-virtualization layer


### PR DESCRIPTION
The main aim of this PR is to remove product-specific code from meta-xt-rpi5 meta-layer. But during those activities I have found a couple of other issues that I fixed as well.