### PR TITLE
u-boot: Remove force enabling u-boot for Raspberry Pi 5

### DIFF
--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,3 +1,0 @@
-UBOOT_MACHINE = "rpi_arm64_config"
-
-COMPATIBLE_MACHINE:raspberrypi5 = "raspberrypi5"


### PR DESCRIPTION
u-boot enabling for Rpi5 is not needed because latest meta-raspberrypi meta layer enables u-boot usage for Raspberry Pi 5.