### PR TITLE
Backport to v0.1:xen: Use hardcoded commit instead latest.

### DIFF
--- a/recipes-extended/xen/xen-source.inc
+++ b/recipes-extended/xen/xen-source.inc
@@ -2,4 +2,4 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d1a1e216f80b6d8da95fec897d0dbec9"
 
 XEN_URL = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.19-xt0.1"
 XEN_REL = "4.19"
-XEN_REV = "${AUTOREV}"
+XEN_REV = "8ff1f6708ab960c4e1f17d4a8ee1dd273538e843"


### PR DESCRIPTION
Use hardcoded commit instead latest. As this meta-layer can be used by multiple products, it is crucial to fix known working revisions, so depending products can make stable releases based on this meta-layer.


Reviewed-by: Grygorii Strashko <grygorii_strashko@epam.com>
Acked-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>