### PR TITLE
linux: Add nvme support in domd

### DIFF
--- a/recipes-bsp/xt-rpi-u-boot-scr/xt-rpi-u-boot-scr.bb
+++ b/recipes-bsp/xt-rpi-u-boot-scr/xt-rpi-u-boot-scr.bb
@@ -16,6 +16,7 @@ SRC_URI = " \
 "
 MMC_PASSTHROUGH_DTBO = "mmc-passthrough.dtbo"
 USB_PASSTHROUGH_DTBO = "usb-passthrough.dtbo"
+PCIE1_PASSTHROUGH_DTBO = "pcie1-passthrough.dtbo"
 BOOT_MEDIA ?= "mmc"
 DOM0_IMAGE ?= "zephyr.bin"
 DOM0_IMG_ADDR ?= "0xe00000"
@@ -47,6 +48,10 @@ do_compile() {
     fi
     if ${@bb.utils.contains("MACHINE_FEATURES", "domd_usb", "true", "false" ,d)}; then
         echo "fatload ${BOOT_MEDIA} 0 ${XEN_DTBO_ADDR} ${USB_PASSTHROUGH_DTBO}" >> ${WORKDIR}/${TEMPLATE_FILE}
+        echo "fdt apply ${XEN_DTBO_ADDR}" >> ${WORKDIR}/${TEMPLATE_FILE}
+    fi
+    if ${@bb.utils.contains("MACHINE_FEATURES", "domd_nvme", "true", "false" ,d)}; then
+        echo "fatload ${BOOT_MEDIA} 0 ${XEN_DTBO_ADDR} ${PCIE1_PASSTHROUGH_DTBO}" >> ${WORKDIR}/${TEMPLATE_FILE}
         echo "fdt apply ${XEN_DTBO_ADDR}" >> ${WORKDIR}/${TEMPLATE_FILE}
     fi
 

--- a/recipes-kernel/linux/files/bcm2712-raspberrypi5-pcie1.dtso
+++ b/recipes-kernel/linux/files/bcm2712-raspberrypi5-pcie1.dtso
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 EPAM systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/dts-v1/;
+/plugin/;
+
+&passthrough {
+	pcie1: pcie@1000110000 {
+		compatible = "brcm,bcm2712-pcie";
+		device_type = "pci";
+		max-link-speed = <2>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		#interrupt-cells = <1>;
+		reg = <0x10 0x00110000  0x0 0x9310>;
+		interrupt-parent = <&gic>;
+		interrupts = <0x00 0xdf 0x04 0x00 0xe0 0x04>;
+		interrupt-names = "pcie", "msi";
+		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
+		interrupt-map = <0x00 0x00 0x00 0x01 &gic 0x00 0xdb 0x04>,
+				<0x00 0x00 0x00 0x02 &gic 0x00 0xdc 0x04>,
+				<0x00 0x00 0x00 0x03 &gic 0x00 0xdd 0x04>,
+				<0x00 0x00 0x00 0x04 &gic 0x00 0xde 0x04>;
+		msi-controller;
+		/*
+		 * HACK: But the mip1: msi-controller@131000 doesn't have IRQs defined
+		 * in the standard way and instead uses custom properties:
+		 * brcm,msi-base-spi to define GIC IRQ offset, and brcm,msi-num-spis
+		 * to define number of GIC IRQs to use. The Xen doesn't understand this
+		 * and so can't map interrupts to DomU in case of 'xen,passthrough'.
+		 */
+//		msi-parent = <&mip1>;
+		msi-parent = <&pcie1>;
+		ranges = <0x02000000 0x00 0x00000000 0x1b 0x00000000 0x00 0xfffffffc>,
+			 <0x43000000 0x04 0x00000000 0x18 0x00000000 0x03 0x00000000>;
+
+		dma-ranges = <0x03000000 0x10 0x00000000 0x00 0x00000000 0x10 0x00000000>;
+
+		resets = <&reset_controller1504318 7>,
+			 <&reset_controller1504318 43>,
+			 <&reset_controller119500>;
+		reset-names = "swinit", "bridge", "rescal";
+		brcm,enable-l1ss;
+		xen,path = "/axi/pcie@110000";
+		xen,force-assign-without-iommu;
+		xen,reg = <0x10 0x110000 0x0 0xA000 0x10 0x110000>,
+			  <0x1b 0x00 0x0 0x600000 0x1b 0x00>;
+		status = "okay";
+	};
+};

--- a/recipes-kernel/linux/files/pcie1-passthrough.dtso
+++ b/recipes-kernel/linux/files/pcie1-passthrough.dtso
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 EPAM systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/dts-v1/;
+/plugin/;
+
+&pcie1       { xen,passthrough; };

--- a/recipes-kernel/linux/linux-raspberrypi_6.6.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi_6.6.bbappend
@@ -5,14 +5,17 @@ DOMU_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-domd"
 XEN_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-xen"
 USB_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-usb"
 MMC_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-mmc"
+PCIE1_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-pcie1"
 
 RPI_KERNEL_DEVICETREE:append = " \
     broadcom/${DOMU_DT_NAME}.dtb \
     broadcom/${XEN_DT_NAME}.dtbo \
     broadcom/${USB_DT_NAME}.dtbo \
     broadcom/${MMC_DT_NAME}.dtbo \
+    broadcom/${PCIE1_DT_NAME}.dtbo \
     broadcom/mmc-passthrough.dtbo \
     broadcom/usb-passthrough.dtbo \
+    broadcom/pcie1-passthrough.dtbo \
 "
 
 KERNEL_IMAGETYPES:append = " Image.gz"
@@ -23,7 +26,9 @@ SRC_URI:append = " \
     file://${XEN_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://${USB_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://${MMC_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
+    file://${PCIE1_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://mmc-passthrough.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://usb-passthrough.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
+    file://pcie1-passthrough.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://0001-drivers-mmc-host-sdhci-brcmstb-fix-no-pinctrl-case.patch \
 "


### PR DESCRIPTION
pcie connector on Raspberry Pi5 connected to the pcie1 device. In frame of this task the following actions were performed:
- Add pcie1 node to domd device tree
- Add xen,passthrough property to the pcie1 node in xen dt