### PR TITLE
u-boot: update u-boot revision to apply PCI fix

### DIFF
--- a/recipes-bsp/u-boot/u-boot-src.inc
+++ b/recipes-bsp/u-boot/u-boot-src.inc
@@ -1,2 +1,2 @@
-SRCREV = "5f19ce099d7e4eca6f46e767dfc48e8d1e78a746"
+SRCREV = "8532e54303e58e11b32c838fbc9c4e14bcccadc4"
 SRC_URI = "git://github.com/xen-troops/u-boot.git;protocol=https;branch=rpi5-2024.04-xt"


### PR DESCRIPTION
Apply u-boot fix to handle more then one PCI device attached. This was leading to unexpected hungs in the linux kernel after u-boot initializes PCI.