### PR TITLE
resipes-bsp: u-boot update revision to include the latest fixes

### DIFF
--- a/recipes-bsp/u-boot/u-boot-src.inc
+++ b/recipes-bsp/u-boot/u-boot-src.inc
@@ -1,2 +1,2 @@
-SRCREV = "8532e54303e58e11b32c838fbc9c4e14bcccadc4"
+SRCREV = "b81bc374c351ec9e5804c7de7163b77b3924bc76"
 SRC_URI = "git://github.com/xen-troops/u-boot.git;protocol=https;branch=rpi5-2024.04-xt"


### PR DESCRIPTION
Updating u-boot revision in the meta-layer. It will add linux header to the result u-boot image so Raspberry-PI will treat u-boot as the Linux Kernel image and place it in the different address.

This overcomes and issue with the newer version of the RPI5 firmware which loads non-kernel images to the predefined address.