### PR TITLE
dts: Add can support

### DIFF
--- a/recipes-kernel/linux/files/bcm2712-raspberrypi5-can.dtso
+++ b/recipes-kernel/linux/files/bcm2712-raspberrypi5-can.dtso
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 EPAM systems
+ *
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/dts-v1/;
+/plugin/;
+
+&passthrough {
+	can1_osc: can1_osc {
+		#clock-cells = <0x00>;
+		clock-frequency = <0xf42400>;
+		compatible = "fixed-clock";
+	};
+
+	can0_osc: can0_osc {
+		#clock-cells = <0x00>;
+		clock-frequency = <0xf42400>;
+		compatible = "fixed-clock";
+	};
+};
+
+
+&gpiod0000 {
+	can1_pins: can1_pins {
+		brcm,function = <0x00>;
+		brcm,pins = <0x19>;
+	};
+
+	can0_pins: can0_pins {
+		brcm,function = <0x00>;
+		brcm,pins = <0x17>;
+	};
+
+	spi0_pins: rp1_spi0_gpio9 {
+		function = "spi0";
+		pins = "gpio9", "gpio10", "gpio11";
+		drive-strength = <0x0c>;
+		bias-disable;
+		slew-rate = <0x01>;
+	};
+
+	spi0_cs_pins: rp1_spi0_cs_gpio7 {
+		function = "spi0";
+		pins = "gpio7", "gpio8";
+		bias-pull-up;
+	};
+};
+
+&rp1 {
+	rp1_dma: dma@188000 {
+		snps,data-width = <0x04>;
+		snps,priority = <0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07>;
+		clock-names = "core-clk", "cfgr-clk";
+		interrupts = <0x28 0x04>;
+		clocks = <&clocks18000 0x0e &clocks18000 0x0c>;
+		snps,axi-max-burst-len = <0x04>;
+		snps,dma-masters = <0x01>;
+		compatible = "snps,axi-dma-1.01a";
+		status = "okay";
+		snps,block-size = <0x40000 0x40000 0x40000 0x40000 0x40000 0x40000 0x40000 0x40000>;
+		reg = <0xc0 0x40188000 0x00 0x1000>;
+		snps,dma-targets = <0x40>;
+		dma-channels = <0x08>;
+		#dma-cells = <0x01>;
+	};
+
+	rp1_spi0: spi@50000 {
+		pinctrl-names = "default";
+		#address-cells = <0x01>;
+		num-cs = <0x02>;
+		pinctrl-0 = <&spi0_pins>, <&spi0_cs_pins>;
+		clock-names = "ssi_clk";
+		interrupts = <0x13 0x04>;
+		clocks = <&clocks18000 0x0c>;
+		#size-cells = <0x00>;
+		dma-names = "tx", "rx";
+		compatible = "snps,dw-apb-ssi";
+		status = "okay";
+		reg = <0xc0 0x40050000 0x00 0x130>;
+		dmas = <&rp1_dma 0x0d>,
+		       <&rp1_dma 0x0c>;
+		cs-gpios = <&gpiod0000 0x08 0x01>, <&gpiod0000 0x07 0x01>;
+
+		can1: mcp2515@1 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&can1_pins>;
+			interrupts = <0x19 0x08>;
+			clocks = <&can1_osc>;
+			spi-max-frequency = <0x989680>;
+			interrupt-parent = <&gpiod0000>;
+			compatible = "microchip,mcp2515";
+			reg = <0x01>;
+		};
+
+		can0: mcp2515@0 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&can0_pins>;
+			interrupts = <0x17 0x08>;
+			clocks = <&can0_osc>;
+			spi-max-frequency = <0x989680>;
+			interrupt-parent = <&gpiod0000>;
+			compatible = "microchip,mcp2515";
+			reg = <0x00>;
+		};
+	};
+};

--- a/recipes-kernel/linux/linux-raspberrypi_6.6.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi_6.6.bbappend
@@ -6,6 +6,7 @@ XEN_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-xen"
 USB_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-usb"
 MMC_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-mmc"
 PCIE1_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-pcie1"
+CAN_DT_NAME = "${RPI_SOC_FAMILY}-${MACHINE}-can"
 
 RPI_KERNEL_DEVICETREE:append = " \
     broadcom/${DOMU_DT_NAME}.dtb \
@@ -13,6 +14,7 @@ RPI_KERNEL_DEVICETREE:append = " \
     broadcom/${USB_DT_NAME}.dtbo \
     broadcom/${MMC_DT_NAME}.dtbo \
     broadcom/${PCIE1_DT_NAME}.dtbo \
+    broadcom/${CAN_DT_NAME}.dtbo \
     broadcom/mmc-passthrough.dtbo \
     broadcom/usb-passthrough.dtbo \
     broadcom/pcie1-passthrough.dtbo \
@@ -27,6 +29,7 @@ SRC_URI:append = " \
     file://${USB_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://${MMC_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://${PCIE1_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
+    file://${CAN_DT_NAME}.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://mmc-passthrough.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://usb-passthrough.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \
     file://pcie1-passthrough.dtso;subdir=git/arch/${ARCH}/boot/dts/broadcom \


### PR DESCRIPTION
According to a device tree, generated by Raspberry Pi OS using the doc for 2-CH CAN Hat (link below), both nodes mcp2515 are connected to rp1_spi0 (spi@50000), which is the part of rp1,  which depends on pcie2 (pcie@1000120000). rp1 is already used by Linux operated driver domain. Also, can1_pins, can0_pins, rp1_spi0_gpio9, rp1_spi0_cs_gpio7 are connected to gpiod0000 (gpio@c0400d00000) that is also already used here.

Therefore, implement CAN support to domd by adding a device tree overlay bcm2712-raspberrypi5-can.dtso with the described required pins, clocks, dma, and spi, and changing a linux-raspberrypi_6.6.bbappend file to add this overlay file to the build.

The documentation for 2-CH CAN Hat:
https://www.waveshare.com/wiki/2-CH_CAN_HAT#Documentation


@firscity @lorc @GrygiriiS @oleksiimoisieiev