### PR TITLE
dts: Adjust a device tree on domd to add CAN support of the MCP251XFD chip

### DIFF
--- a/recipes-kernel/linux/files/bcm2712-raspberrypi5-can.dtso
+++ b/recipes-kernel/linux/files/bcm2712-raspberrypi5-can.dtso
@@ -7,29 +7,29 @@
 /plugin/;
 
 &passthrough {
-	can1_osc: can1_osc {
+	can1_osc: mcp251xfd-spi0-1-osc {
 		#clock-cells = <0x00>;
-		clock-frequency = <0xf42400>;
+		clock-frequency = <40000000>;
 		compatible = "fixed-clock";
 	};
 
-	can0_osc: can0_osc {
+	can0_osc: mcp251xfd-spi0-0-osc {
 		#clock-cells = <0x00>;
-		clock-frequency = <0xf42400>;
+		clock-frequency = <40000000>;
 		compatible = "fixed-clock";
 	};
 };
 
 
 &gpiod0000 {
-	can1_pins: can1_pins {
+	can1_pins: mcp251xfd_spi0_1_pins {
 		brcm,function = <0x00>;
-		brcm,pins = <0x19>;
+		brcm,pins = <0x18>;
 	};
 
-	can0_pins: can0_pins {
+	can0_pins: mcp251xfd_spi0_0_pins {
 		brcm,function = <0x00>;
-		brcm,pins = <0x17>;
+		brcm,pins = <0x19>;
 	};
 
 	spi0_pins: rp1_spi0_gpio9 {
@@ -43,6 +43,13 @@
 	spi0_cs_pins: rp1_spi0_cs_gpio7 {
 		function = "spi0";
 		pins = "gpio7", "gpio8";
+		bias-pull-up;
+	};
+
+	i2c1_pins: rp1_i2c1_2_3 {
+		function = "i2c1";
+		pins = "gpio2", "gpio3";
+		drive-strength = <0x0c>;
 		bias-pull-up;
 	};
 };
@@ -82,26 +89,46 @@
 		       <&rp1_dma 0x0c>;
 		cs-gpios = <&gpiod0000 0x08 0x01>, <&gpiod0000 0x07 0x01>;
 
-		can1: mcp2515@1 {
+		can1: mcp251xfd@1 {
 			pinctrl-names = "default";
 			pinctrl-0 = <&can1_pins>;
-			interrupts = <0x19 0x08>;
+			interrupts = <0x18 0x08>;
 			clocks = <&can1_osc>;
-			spi-max-frequency = <0x989680>;
+			spi-max-frequency = <20000000>;
 			interrupt-parent = <&gpiod0000>;
-			compatible = "microchip,mcp2515";
+			compatible = "microchip,mcp251xfd";
 			reg = <0x01>;
 		};
 
-		can0: mcp2515@0 {
+		can0: mcp251xfd@0 {
 			pinctrl-names = "default";
 			pinctrl-0 = <&can0_pins>;
-			interrupts = <0x17 0x08>;
+			interrupts = <0x19 0x08>;
 			clocks = <&can0_osc>;
-			spi-max-frequency = <0x989680>;
+			spi-max-frequency = <20000000>;
 			interrupt-parent = <&gpiod0000>;
-			compatible = "microchip,mcp2515";
+			compatible = "microchip,mcp251xfd";
 			reg = <0x00>;
+		};
+	};
+
+	i2c@74000 {
+		pinctrl-names = "default";
+		#address-cells = <0x01>;
+		pinctrl-0 = <&i2c1_pins>;
+		i2c-scl-rising-time-ns = <65>;
+		i2c-scl-falling-time-ns = <100>;
+		interrupts = <0x08 0x04>;
+		clocks = <&clocks18000 0x0c>;
+		#size-cells = <0x00>;
+		clock-frequency = <0x186a0>;
+		compatible = "snps,designware-:i2c";
+		status = "okay";
+		reg = <0xc0 0x40074000 0x00 0x1000>;
+
+		pcf85063@51 {
+			compatible = "nxp,pcf85063";
+			reg = <0x51>;
 		};
 	};
 };


### PR DESCRIPTION
DomD CAN support was working with a 2-CH CAN HAT with the MCP2515 chip, but with a 2 Channel CAN BUS FD Shield with the MCP251XFD chip the output is
```
main:~$ dmesg | grep spi
[    4.888283] mcp251x spi0.0: MCP251x didn't enter in conf mode after reset
[    4.904266] mcp251x spi0.0: Probe failed, err=110
[    4.916246] mcp251x: probe of spi0.0 failed with error -110
[    5.932304] mcp251x spi0.1: MCP251x didn't enter in conf mode after reset
[    5.940358] mcp251x spi0.1: Probe failed, err=110
[    5.946398] mcp251x: probe of spi0.1 failed with error -110
```

Therefore, the device tree overlay `bcm2712-raspberrypi5-can.dtso` was adjusted to work properly with the MCP251XFD chip.

The documentation with resources for the 2 Channel CAN BUS FD Shield: 
https://wiki.seeedstudio.com/2-Channel-CAN-BUS-FD-Shield-for-Raspberry-Pi/


@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym