### PR TITLE
xen: Add check for option to enable early printk

### DIFF
--- a/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-extended/xen/xen_git.bbappend
@@ -5,7 +5,7 @@ require xen-source.inc
 
 SRC_URI:append = " \
     file://xen-config.cfg \
-    file://xen-early-printk.cfg \
+    ${@bb.utils.contains("XT_EARLY_PRINTK", "enable", " file://xen-early-printk.cfg", "", d)} \
 "
 
 PACKAGECONFIG:append = " xsm"


### PR DESCRIPTION
Previously, xen-early-printk.cfg was always included in the build. This made early printk support mandatory regardless of configuration. A conditional check for XT_EARLY_PRINTK has been added in xen_git.bbappend so early printk can be disabled as needed.

@firscity @lorc @GrygiriiS @oleksiimoisieiev @rshym